### PR TITLE
Update convert command

### DIFF
--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -24,7 +24,7 @@ export function convert(source: string, destination: string) {
     fs.mkdirSync(dirName, { recursive: true })
     fs.writeFileSync(path.join(dirName, fileName), layerYml)
 
-    layers.push(`!!inc/file ${path.join(dirName, fileName)}`)
+    layers.push(`!!inc/file ${path.join('layers', fileName)}`)
   }
 
   style.layers = layers

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -30,7 +30,9 @@ export function convert(source: string, destination: string) {
   style.layers = layers
 
   try {
-    fs.writeFileSync(destinationPath, YAML.dump(style).replace(/'/g, ''))
+    fs.writeFileSync(destinationPath, YAML.dump(style).replace(/'\!\!inc\/file layers\/.+\.yml'/g, function (match) {
+      return match.replace(/'/g, '')
+    }))
   } catch(err) {
     // TODO: Error handling
   }

--- a/test/data/convert.json
+++ b/test/data/convert.json
@@ -1,0 +1,23 @@
+{
+  "version": 8,
+  "name": "example",
+  "metadata": {},
+  "sources": {
+    "geolonia": {
+      "type": "vector",
+      "url": "https://api.geolonia.com/v1/sources?key=YOUR-API-KEY"
+    }
+  },
+  "sprite": "https://sprites.geolonia.com/basic-white",
+  "glyphs": "https://glyphs.geolonia.com/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "rgba(19, 28, 54, 1)"
+      }
+    }
+  ],
+  "id": "example"
+}

--- a/test/test-convert.ts
+++ b/test/test-convert.ts
@@ -1,0 +1,46 @@
+import { assert } from 'chai'
+import path from 'path'
+import fs from 'fs'
+
+import { convert } from '../src/commands/convert'
+
+describe('Test for the `convert.ts`.', () => {
+
+  const jsonPath = path.join(__dirname, 'data/convert.json')
+  const yamlPath = path.join(__dirname, 'data/convert.yml')
+  const layerPath = path.join(__dirname, 'data/layers/background.yml')
+
+  afterEach(function(){
+    fs.unlinkSync(yamlPath)
+    fs.rmSync(path.join(__dirname, 'data/layers'), {recursive:true})
+  });
+
+  it('Should convert `data/convert.json` to YAML.', () => {
+
+    convert(jsonPath, yamlPath)
+    const yml = fs.readFileSync(yamlPath, 'utf-8')
+
+    assert.equal(`version: 8
+name: example
+metadata: {}
+sources:
+  geolonia:
+    type: vector
+    url: https://api.geolonia.com/v1/sources?key=YOUR-API-KEY
+sprite: https://sprites.geolonia.com/basic-white
+glyphs: https://glyphs.geolonia.com/{fontstack}/{range}.pbf
+layers:
+  - !!inc/file layers/background.yml
+id: example
+`, yml)
+  });
+
+  it('Should create layers directory.', () => {
+
+    convert(jsonPath, yamlPath)
+
+    const result = fs.existsSync(layerPath)
+
+    assert.equal(true, result)
+  })
+});


### PR DESCRIPTION
`convert` コマンドの修正をしました。

- 分割した yml を 相対パスで include するように変更 （例:  `!!inc/file layers/background.yml`）
- シングルクォーテーションの正規表現を改善
  - https://github.com/geolonia/charites/blob/update-convert-command/src/commands/convert.ts#L33-L35 
- convert コマンドのテストを追加。