### PR TITLE
Update convert test

### DIFF
--- a/test/convert.spec.ts
+++ b/test/convert.spec.ts
@@ -1,19 +1,15 @@
 import { assert } from 'chai'
 import path from 'path'
 import fs from 'fs'
+import os from 'os'
 
 import { convert } from '../src/commands/convert'
 
 describe('Test for the `convert.ts`.', () => {
 
   const jsonPath = path.join(__dirname, 'data/convert.json')
-  const yamlPath = path.join(__dirname, 'data/convert.yml')
-  const layerPath = path.join(__dirname, 'data/layers/background.yml')
-
-  afterEach(function(){
-    fs.unlinkSync(yamlPath)
-    fs.rmSync(path.join(__dirname, 'data/layers'), {recursive:true})
-  });
+  const yamlPath = path.join(os.tmpdir(), 'convert.yml')
+  const layerPath = path.join(os.tmpdir(), 'layers/background.yml')
 
   it('Should convert `data/convert.json` to YAML.', () => {
 

--- a/test/convert.spec.ts
+++ b/test/convert.spec.ts
@@ -7,9 +7,10 @@ import { convert } from '../src/commands/convert'
 
 describe('Test for the `convert.ts`.', () => {
 
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'charites-'))
   const jsonPath = path.join(__dirname, 'data/convert.json')
-  const yamlPath = path.join(os.tmpdir(), 'convert.yml')
-  const layerPath = path.join(os.tmpdir(), 'layers/background.yml')
+  const yamlPath = path.join(tmp, 'convert.yml')
+  const layerPath = path.join(tmp, 'layers/background.yml')
 
   it('Should convert `data/convert.json` to YAML.', () => {
 


### PR DESCRIPTION
テスト時に作成するファイルを、一時ディクレトリの直下に、`mkdtempSync` を使ってランダムなフォルダを作成し配置するように変更しました。

https://nodejs.org/api/fs.html#fs_fs_mkdtempsync_prefix_options