### PR TITLE
Serve with static files in the local directory

### DIFF
--- a/docs/source/usage/commandline_interface.rst
+++ b/docs/source/usage/commandline_interface.rst
@@ -26,7 +26,7 @@ Inititalize `style.yml`
 
 .. code-block:: bash
 
-    $ charites init -h  
+    $ charites init -h
     Usage: charites init [options] <file>
 
     initialize a style JSON
@@ -77,7 +77,7 @@ Realtime editor on browser
 --------------------------
 
 .. code-block:: bash
-    
+
     charites serve -h
     Usage: charites serve [options] <source>
 
@@ -86,13 +86,18 @@ Realtime editor on browser
     Options:
     --provider [provider]                      your map service. e.g. `mapbox`, `geolonia`
     --mapbox-access-token [mapboxAccessToken]  Access Token for the Mapbox
+    --local-dir [localDirPath]                 also serve files in the local directory
     -h, --help                                 display help for command
 
-Charites has two options for `serve` command.
+Charites has three options for `serve` command.
 
 - `--provider` - `mapbox`, `geolonia`, or `default`. When not specified, default or the value in the configuration file will be used.
 
   - `mapbox` - The format linter runs against the Mapbox GL JS v2.x compatible specification.
   - `geolonia` and `default` - the format linter runs against the MapLibre GL JS compatible specification.
-  
+
 - `--mapbox-access-token` - Set your access-token when styling for Mapbox.
+
+- `--local-dir` - Serve static files on the local directory.
+
+  - NOTE: `index.html`, `/style.json`, `/app.css`, `/app.js` will swap to provider files

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -17,6 +17,10 @@ program
     '--mapbox-access-token [mapboxAccessToken]',
     'Access Token for the Mapbox',
   )
+  .option(
+    '--local-dir [localDirPath]',
+    'also serve files in the local directory',
+  )
   .action((source: string, serveOptions: serveOptions) => {
     const options: serveOptions = program.opts()
     options.provider = serveOptions.provider

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -12,6 +12,7 @@ import { defaultValues } from '../lib/defaultValues'
 export interface serveOptions {
   provider?: string
   mapboxAccessToken?: string
+  localDir?: string
 }
 
 export function serve(source: string, options: serveOptions) {
@@ -30,6 +31,14 @@ export function serve(source: string, options: serveOptions) {
 
   if (!fs.existsSync(sourcePath)) {
     throw `${sourcePath}: No such file or directory`
+  }
+
+  let localDirPath: string
+  if (options.localDir) {
+    localDirPath = path.resolve(process.cwd(), options.localDir)
+    if (!fs.existsSync(localDirPath)) {
+      throw `${localDirPath}: No such file or directory`
+    }
   }
 
   const server = http.createServer((req, res) => {
@@ -75,6 +84,18 @@ export function serve(source: string, options: serveOptions) {
           res.end(js)
         } catch (e) {
           throw `Invalid provider: ${provider}`
+        }
+        break
+      default:
+        if (options.localDir) {
+          const filePath = path.join(localDirPath + path.normalize(url))
+          console.log(url)
+          console.log(filePath)
+          if (fs.existsSync(filePath)) {
+            const file = fs.readFileSync(filePath)
+            res.statusCode = 200
+            res.end(file)
+          }
         }
         break
     }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -89,8 +89,6 @@ export function serve(source: string, options: serveOptions) {
       default:
         if (options.localDir) {
           const filePath = path.join(localDirPath + path.normalize(url))
-          console.log(url)
-          console.log(filePath)
           if (fs.existsSync(filePath)) {
             const file = fs.readFileSync(filePath)
             res.statusCode = 200


### PR DESCRIPTION
## Description

Add capability to serve additional static files in the local directory for charites.

That means charites gets capability to serve tilesets itself
if tiles has split as  `/{z}/{x}/{y}/*.pbf` style in the local directory.

This pull request possibly related to issue #73

### Why

Currently charites has no capability to serve any tilesets itself.
So charites require another server that serving some tilesets.

This can be a problem if you have a poor connection or are cut off from the Internet.
I would like to be able to edit map styles without having to set up another server.

In addition, this can turn charites into a complete map server on its own.

### Example

This pull request add capability to serve vector tile tilesets in the local directory.

1. Create vector tile to `./docs/zxy/{z}/{x}/{y}/*.pbf`

2. Write or generate TileJSON to `docs/tiles.json` like below

```tiles.json
  "tiles": [
    "http://localhost:8080/zxy/{z}/{x}/{y}.pbf"
  ]
```

3. Write `style.yml` like below

```style.yml
sources:
  openmaptiles:
    type: vector
    url: ./tiles.json
```

4. Run `charites serve style.yml --local-dir docs`

Open http://localhost:8080/ without connection to Internet. That will works.


## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the exsiting features working well
- [x] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
