### PR TITLE
Add `--watch` option to `charites build` command

### DIFF
--- a/docs/source/usage/commandline_interface.rst
+++ b/docs/source/usage/commandline_interface.rst
@@ -26,7 +26,7 @@ Inititalize `style.yml`
 
 .. code-block:: bash
 
-    $ charites init -h  
+    $ charites init -h
     Usage: charites init [options] <file>
 
     initialize a style JSON
@@ -65,6 +65,7 @@ Build `style.json` from `style.yml`
 
     Options:
     -c, --compact-output                           build a minified style JSON
+    -w, --watch                                    watch YAML and build when changed
     -u, --sprite-url [<sprite url>]                url to set as the sprite in style.json
     -i, --sprite-input [<icon input directory>]    directory path of icon source to build icons. The default <icon source> is `icons/`
     -o, --sprite-output [<icon output directory>]  directory path to output icon files. The default <icons destination> is the current directory
@@ -77,7 +78,7 @@ Realtime editor on browser
 --------------------------
 
 .. code-block:: bash
-    
+
     charites serve -h
     Usage: charites serve [options] <source>
 
@@ -94,5 +95,5 @@ Charites has two options for `serve` command.
 
   - `mapbox` - The format linter runs against the Mapbox GL JS v2.x compatible specification.
   - `geolonia` and `default` - the format linter runs against the MapLibre GL JS compatible specification.
-  
+
 - `--mapbox-access-token` - Set your access-token when styling for Mapbox.

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -7,10 +7,12 @@ import { getSpriteSlug } from '../lib/get-sprite-slug'
 import { defaultValues } from '../lib/defaultValues'
 import jsonminify from 'jsonminify'
 import { StyleSpecification } from '@maplibre/maplibre-gl-style-spec/types'
+import watch from 'node-watch'
 
 export interface buildOptions {
   provider?: string
   compactOutput?: boolean
+  watch?: boolean
   spriteUrl?: string
   spriteInput?: string
   spriteOutput?: string
@@ -97,4 +99,28 @@ export async function build(
   } catch (err) {
     throw `${destinationPath}: Permission denied`
   }
+}
+
+export function buildWatch(
+  source: string,
+  destination: string,
+  options: buildOptions,
+) {
+  let sourcePath = path.resolve(process.cwd(), source)
+  if (source.match(/^\//)) {
+    sourcePath = source
+  }
+  console.log(path.dirname(sourcePath))
+  return watch(
+    path.dirname(sourcePath),
+    { recursive: true, filter: /\.yml$/ },
+    (event, file) => {
+      console.log(`${(event || '').toUpperCase()}: ${file}`)
+      try {
+        build(source, destination, options)
+      } catch (e) {
+        // Nothing to do
+      }
+    },
+  )
 }

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import fs from 'fs'
 import os from 'os'
 
-import { build } from '../src/commands/build'
+import { build, buildWatch } from '../src/commands/build'
 import { defaultValues } from '../src/lib/defaultValues'
 
 describe('Test for the `build.ts`.', () => {
@@ -113,5 +113,27 @@ describe('Test for the `build.ts`.', () => {
     } catch (error) {
       assert.deepEqual(true, !!error) // It should have something error.
     }
+  })
+
+  it('Should watch `*.yml` and convert it to JSON', async () => {
+    const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms))
+    console.log(styleJson)
+
+    const watcher = buildWatch(styleYaml, styleJson, {
+      provider: defaultValues.provider,
+    })
+    await sleep(500)
+    const yamlData1 = fs
+      .readFileSync(styleYaml, 'utf-8')
+      .replace('metadata: {}', 'metadata: aaa')
+    fs.writeFileSync(styleYaml, yamlData1)
+    await sleep(500)
+    await watcher.close()
+    assert.deepEqual(true, !!fs.statSync(styleJson))
+    assert.deepEqual(8, JSON.parse(fs.readFileSync(styleJson, 'utf-8')).version)
+    const yamlData2 = fs
+      .readFileSync(styleYaml, 'utf-8')
+      .replace('metadata: aaa', 'metadata: {}')
+    fs.writeFileSync(styleYaml, yamlData2)
   })
 })

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -129,7 +129,10 @@ describe('Test for the `build.ts`.', () => {
     await sleep(500)
     await watcher.close()
     assert.deepEqual(true, !!fs.statSync(styleJson))
-    assert.deepEqual(8, JSON.parse(fs.readFileSync(styleJson, 'utf-8')).version)
+    assert.deepEqual(
+      'aaa',
+      JSON.parse(fs.readFileSync(styleJson, 'utf-8')).metadata,
+    )
     const yamlData2 = fs
       .readFileSync(styleYaml, 'utf-8')
       .replace('metadata: aaa', 'metadata: {}')

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -117,7 +117,6 @@ describe('Test for the `build.ts`.', () => {
 
   it('Should watch `*.yml` and convert it to JSON', async () => {
     const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms))
-    console.log(styleJson)
 
     const watcher = buildWatch(styleYaml, styleJson, {
       provider: defaultValues.provider,


### PR DESCRIPTION
## Description

Add `--watch` (short hand as `-w`) option to `charites build` command.

Currently, charites can only once build style JSON when `charites build` command has called.
So we need to call `charites build` command every time we change any YAML file.

I suggest to add the option to build and write style JSON each time when YAML files has changed.
This change is doing the same thing what the `charites serve` command is doing internally.

### Background

`charites serve` command is simple and convenient, but has some known limitations.

I want to say what I really wanted is continuously watch files and build, not a live preview or hot reload server.
When I thought about what I really wanted, I believe it would be nice to charites have this feature.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the exsiting features working well
- [x] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
