### PR TITLE
Supports #73: add port option to serve command

### DIFF
--- a/docs/source/usage/commandline_interface.rst
+++ b/docs/source/usage/commandline_interface.rst
@@ -87,9 +87,10 @@ Realtime editor on browser
     Options:
     --provider [provider]                      your map service. e.g. `mapbox`, `geolonia`
     --mapbox-access-token [mapboxAccessToken]  Access Token for the Mapbox
+    --port [port]                              Specify custom port
     -h, --help                                 display help for command
 
-Charites has two options for `serve` command.
+Charites has three options for `serve` command.
 
 - `--provider` - `mapbox`, `geolonia`, or `default`. When not specified, default or the value in the configuration file will be used.
 
@@ -97,3 +98,5 @@ Charites has two options for `serve` command.
   - `geolonia` and `default` - the format linter runs against the MapLibre GL JS compatible specification.
 
 - `--mapbox-access-token` - Set your access-token when styling for Mapbox.
+
+- `--port` - Set http server's port number. When not specified, use 8080 port.

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -17,10 +17,12 @@ program
     '--mapbox-access-token [mapboxAccessToken]',
     'Access Token for the Mapbox',
   )
+  .option('--port [port]', 'Specify custom port')
   .action((source: string, serveOptions: serveOptions) => {
     const options: serveOptions = program.opts()
     options.provider = serveOptions.provider
     options.mapboxAccessToken = serveOptions.mapboxAccessToken
+    options.port = serveOptions.port
     if (!fs.existsSync(defaultSettings.configFile)) {
       fs.writeFileSync(
         defaultSettings.configFile,

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -12,10 +12,14 @@ import { defaultValues } from '../lib/defaultValues'
 export interface serveOptions {
   provider?: string
   mapboxAccessToken?: string
+  port?: string
 }
 
 export function serve(source: string, options: serveOptions) {
-  const port = process.env.PORT || 8080
+  let port = process.env.PORT || 8080
+  if (options.port) {
+    port = Number(options.port)
+  }
   let sourcePath = path.resolve(process.cwd(), source)
 
   let provider = defaultValues.provider


### PR DESCRIPTION
## Description

Supports #73
`serve` command enable to run custom port

## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the exsiting features working well
- [x] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
