### PR TITLE
Fix to print error message

### DIFF
--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,6 +1,10 @@
 export const error = (e: unknown) => {
+
   if (e instanceof TypeError) {
     console.error(e.message)
+  } else if (typeof e === 'string') {
+    console.error(e)
   }
+
   process.exit(1)
 }

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,8 +1,9 @@
 export const error = (e: unknown) => {
   if (e instanceof TypeError) {
     console.error(e.message)
-  } else if (typeof e === 'string') {
-    console.error(e)
+  } else {
+    // @ts-ignore
+    console.error(e.toString())
   }
   process.exit(1)
 }

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,10 +1,8 @@
 export const error = (e: unknown) => {
-
   if (e instanceof TypeError) {
     console.error(e.message)
   } else if (typeof e === 'string') {
     console.error(e)
   }
-
   process.exit(1)
 }

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,9 +1,8 @@
 export const error = (e: unknown) => {
-  if (e instanceof TypeError) {
+  if (e instanceof Error) {
     console.error(e.message)
   } else {
-    // @ts-ignore
-    console.error(e.toString())
+    console.error(String(e))
   }
   process.exit(1)
 }

--- a/test/command.build.spec.ts
+++ b/test/command.build.spec.ts
@@ -63,28 +63,25 @@ describe('Test for the `charites build`', () => {
   })
 
   it('charites build style.yml style.json --sprite-url http://localhost:8080', async () => {
-
     try {
       // prettier-ignore
       await exec(`${charites} build style.yml style.json --sprite-url http://localhost:8080`, tmpdir)
-
     } catch (error) {
-
       assert.deepEqual(error.stdout, '')
       assert.deepEqual(error.stderr, 'Invalid sprite url format.\n')
     }
   })
 
   it('charites build style.yml style.json --sprite-output noExistDirname', async () => {
-
     try {
       // prettier-ignore
       await exec(`${charites} build style.yml style.json --sprite-output noExistDirname`, tmpdir)
-
     } catch (error) {
-
       assert.deepEqual(error.stdout, '')
-      assert.deepEqual(error.stderr, 'noExistDirname: No such directory. Please specify valid icon output directory. For more help run charites build --help\n')
+      assert.deepEqual(
+        error.stderr,
+        'noExistDirname: No such directory. Please specify valid icon output directory. For more help run charites build --help\n',
+      )
     }
   })
 })

--- a/test/command.build.spec.ts
+++ b/test/command.build.spec.ts
@@ -61,4 +61,30 @@ describe('Test for the `charites build`', () => {
     assert.isTrue(fs.existsSync(path.join(tmpdir, 'basic-white.png')))
     assert.isTrue(fs.existsSync(path.join(tmpdir, 'basic-white.json')))
   })
+
+  it('charites build style.yml style.json --sprite-url http://localhost:8080', async () => {
+
+    try {
+      // prettier-ignore
+      await exec(`${charites} build style.yml style.json --sprite-url http://localhost:8080`, tmpdir)
+
+    } catch (error) {
+
+      assert.deepEqual(error.stdout, '')
+      assert.deepEqual(error.stderr, 'Invalid sprite url format.\n')
+    }
+  })
+
+  it('charites build style.yml style.json --sprite-output noExistDirname', async () => {
+
+    try {
+      // prettier-ignore
+      await exec(`${charites} build style.yml style.json --sprite-output noExistDirname`, tmpdir)
+
+    } catch (error) {
+
+      assert.deepEqual(error.stdout, '')
+      assert.deepEqual(error.stderr, 'noExistDirname: No such directory. Please specify valid icon output directory. For more help run charites build --help\n')
+    }
+  })
 })

--- a/test/command.build.spec.ts
+++ b/test/command.build.spec.ts
@@ -72,6 +72,19 @@ describe('Test for the `charites build`', () => {
     }
   })
 
+  it('charites build style.yml style.json --sprite-input noExistDirname', async () => {
+    try {
+      // prettier-ignore
+      await exec(`${charites} build style.yml style.json --sprite-input noExistDirname`, tmpdir)
+    } catch (error) {
+      assert.deepEqual(error.stdout, '')
+      assert.deepEqual(
+        error.stderr,
+        'noExistDirname: No such directory. Please specify valid icon input directory. For more help run charites build --help\n',
+      )
+    }
+  })
+
   it('charites build style.yml style.json --sprite-output noExistDirname', async () => {
     try {
       // prettier-ignore


### PR DESCRIPTION
@keichan34 @kamataryo @JinIgarashi. I fixed the bug, could you review this PR?
cc @ubukawa @hfu 

## Description

Fix to print error message. 

When we run `charites build style.yml style.json --sprite-url http://localhost:8080`, Charites should return `Invalid sprite url format.`. But, it hasn't return any error message. So, I fixed it.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the exsiting features working well
- [ ] Have you added at least one unit test if you are going to add new feature?
- [ ] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
