### PR TITLE
Return 404 not found when paths don't match

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -81,6 +81,11 @@ export function serve(source: string, options: serveOptions) {
           throw `Invalid provider: ${provider}`
         }
         break
+      default:
+        res.statusCode = 404
+        res.setHeader('Content-Type', 'text/plain; charset=UTF-8')
+        res.end('Not found')
+        break
     }
   })
 


### PR DESCRIPTION
## Description

When a path is not matched in the `serve` command, a response is never returned to the client. This makes the server hang if there are a lot of requests to non-existent paths (for example, Chrome will sometimes automatically make a request to `/favicon.ico`).

This fix returns a 404 Not Found response to any request that isn't matched.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the exsiting features working well
- [ ] Have you added at least one unit test if you are going to add new feature?
- [ ] Have you updated documentation?
<!-- ignore-task-list-end -->
