### PR TITLE
add Node.js v18.x to `.github/workflows/build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Today, Node.js v14 is now mentenance LTS, v16 is active LTS.
And then Node.js v18 is current release.

Node.js v18 will be active LTS on 2022-10-25.
So this pull request add Node.js v18.x to build workflow

References:
- https://nodejs.org/en/about/releases/

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [x] Others (tweak GitHub Actions)
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the exsiting features working well
- [ ] Have you added at least one unit test if you are going to add new feature?
- [ ] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
