### PR TITLE
fix broken LegendControl of the `charites serve` command

### DIFF
--- a/provider/default/app.js
+++ b/provider/default/app.js
@@ -13,7 +13,7 @@ socket.addEventListener('message', (message) => {
 map.addControl(new maplibregl.NavigationControl(), 'top-right')
 
 map.addControl(
-  new watergis.MaplibreLegendControl(
+  new MaplibreLegendControl(
     {},
     {
       showDefault: true,

--- a/provider/mapbox/app.js
+++ b/provider/mapbox/app.js
@@ -15,7 +15,7 @@ socket.addEventListener('message', (message) => {
 map.addControl(new mapboxgl.NavigationControl(), 'top-right')
 
 map.addControl(
-  new watergis.MapboxLegendControl(
+  new MapboxLegendControl(
     {},
     {
       showDefault: true,


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fix: #117

- https://github.com/watergis/mapbox-gl-legend does not provide global variable named `watergis` any more
  - Destructive changes may have been made to the https://github.com/watergis/mapbox-gl-legend
- This has broken the LegendControl feature of the charites live preview
- Luckily I was able to fix this easily and I create this pull request


## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Fixing a bug
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the exsiting features working well
- [x] Have you added at least one unit test if you are going to add new feature?
- [x] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.

## Screenshots

### Before

[![Image from Gyazo](https://i.gyazo.com/c9bb408b608cd3ae835725a1b00bbd5b.png)](https://gyazo.com/c9bb408b608cd3ae835725a1b00bbd5b)


### After

[![Image from Gyazo](https://i.gyazo.com/8107c06bb0726b357aac7dc3fbced939.png)](https://gyazo.com/8107c06bb0726b357aac7dc3fbced939)


