### PR TITLE
Show center of tiles when `charites serve` has launched

### DIFF
--- a/provider/default/app.js
+++ b/provider/default/app.js
@@ -13,7 +13,7 @@ socket.addEventListener('message', (message) => {
 map.addControl(new maplibregl.NavigationControl(), 'top-right')
 
 map.addControl(
-  new watergis.MaplibreLegendControl(
+  new MaplibreLegendControl(
     {},
     {
       showDefault: true,

--- a/provider/default/app.js
+++ b/provider/default/app.js
@@ -1,50 +1,67 @@
-const map = new maplibregl.Map({
-  container: 'map',
-  hash: true,
-  style: `http://${window.location.host}/style.json`,
-})
+;(async () => {
+  const mapStyleUrl = `http://${window.location.host}/style.json`
+  const mapStyleRes = await fetch(mapStyleUrl)
+  const mapStyleJson = await mapStyleRes.json()
+  const mapTileUrl =
+    mapStyleJson['sources'][Object.keys(mapStyleJson['sources'])]['url']
+  const mapTileRes = await fetch(mapTileUrl)
+  const mapTileJson = await mapTileRes.json()
+  const bounds = mapTileJson.bounds
+  const center = mapTileJson.center
+    ? mapTileJson.center
+    : [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2]
+  const zoom = (mapTileJson.minzoom + mapTileJson.maxzoom) / 2
 
-const socket = new WebSocket('ws://localhost:___PORT___')
+  const map = new maplibregl.Map({
+    container: 'map',
+    hash: true,
+    style: mapStyleUrl,
+    center: center,
+    zoom: zoom + 4,
+  })
 
-socket.addEventListener('message', (message) => {
-  map.setStyle(JSON.parse(message.data))
-})
+  const socket = new WebSocket('ws://localhost:___PORT___')
 
-map.addControl(new maplibregl.NavigationControl(), 'top-right')
+  socket.addEventListener('message', (message) => {
+    map.setStyle(JSON.parse(message.data))
+  })
 
-map.addControl(
-  new MaplibreLegendControl(
-    {},
-    {
-      showDefault: true,
-      showCheckbox: true,
-      onlyRendered: true,
-      reverseOrder: true,
-    },
-  ),
-  'bottom-left',
-)
+  map.addControl(new maplibregl.NavigationControl(), 'top-right')
 
-const showTileBoundaries = document.getElementById('showTileBoundaries')
-const setShowTileBoundaries = function () {
-  const checked = showTileBoundaries.checked
-  map.showTileBoundaries = checked
-}
-setShowTileBoundaries()
-showTileBoundaries.addEventListener('click', setShowTileBoundaries)
+  map.addControl(
+    new MaplibreLegendControl(
+      {},
+      {
+        showDefault: true,
+        showCheckbox: true,
+        onlyRendered: true,
+        reverseOrder: true,
+      },
+    ),
+    'bottom-left',
+  )
 
-const showCollisionBoxes = document.getElementById('showCollisionBoxes')
-const setShowCollisionBoxes = function () {
-  const checked = showCollisionBoxes.checked
-  map.showCollisionBoxes = checked
-}
-setShowCollisionBoxes()
-showCollisionBoxes.addEventListener('click', setShowCollisionBoxes)
+  const showTileBoundaries = document.getElementById('showTileBoundaries')
+  const setShowTileBoundaries = function () {
+    const checked = showTileBoundaries.checked
+    map.showTileBoundaries = checked
+  }
+  setShowTileBoundaries()
+  showTileBoundaries.addEventListener('click', setShowTileBoundaries)
 
-const showPadding = document.getElementById('showPadding')
-const setShowPadding = function () {
-  const checked = showPadding.checked
-  map.showPadding = checked
-}
-setShowPadding()
-showPadding.addEventListener('click', setShowPadding)
+  const showCollisionBoxes = document.getElementById('showCollisionBoxes')
+  const setShowCollisionBoxes = function () {
+    const checked = showCollisionBoxes.checked
+    map.showCollisionBoxes = checked
+  }
+  setShowCollisionBoxes()
+  showCollisionBoxes.addEventListener('click', setShowCollisionBoxes)
+
+  const showPadding = document.getElementById('showPadding')
+  const setShowPadding = function () {
+    const checked = showPadding.checked
+    map.showPadding = checked
+  }
+  setShowPadding()
+  showPadding.addEventListener('click', setShowPadding)
+})()

--- a/provider/default/app.js
+++ b/provider/default/app.js
@@ -2,22 +2,42 @@
   const mapStyleUrl = `http://${window.location.host}/style.json`
   const mapStyleRes = await fetch(mapStyleUrl)
   const mapStyleJson = await mapStyleRes.json()
-  const mapTileUrl =
-    mapStyleJson['sources'][Object.keys(mapStyleJson['sources'])]['url']
-  const mapTileRes = await fetch(mapTileUrl)
-  const mapTileJson = await mapTileRes.json()
-  const bounds = mapTileJson.bounds
-  const center = mapTileJson.center
-    ? mapTileJson.center
-    : [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2]
-  const zoom = (mapTileJson.minzoom + mapTileJson.maxzoom) / 2
+
+  // detect center & zoom from map style json
+  let center = mapStyleJson.hasOwnProperty('center')
+    ? mapStyleJson.center
+    : undefined
+  let zoom = mapStyleJson.hasOwnProperty('zoom') ? mapStyleJson.zoom : undefined
+
+  // detect center & zoom from tile json
+  if (center === undefined || zoom === undefined) {
+    for (const sourceName in mapStyleJson.sources) {
+      if (
+        mapStyleJson.sources[sourceName].type === 'vector' &&
+        mapStyleJson.sources[sourceName].hasOwnProperty('url')
+      ) {
+        const mapTileUrl = mapStyleJson.sources[sourceName].url
+        const mapTileRes = await fetch(mapTileUrl)
+        const mapTileJson = await mapTileRes.json()
+        if (center === undefined) {
+          const bounds = mapTileJson.bounds
+          center = mapTileJson.center
+            ? mapTileJson.center
+            : [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2]
+        }
+        if (zoom === undefined) {
+          zoom = (mapTileJson.minzoom + mapTileJson.maxzoom) / 2
+        }
+      }
+    }
+  }
 
   const map = new maplibregl.Map({
     container: 'map',
     hash: true,
     style: mapStyleUrl,
     center: center,
-    zoom: zoom + 4,
+    zoom: zoom,
   })
 
   const socket = new WebSocket('ws://localhost:___PORT___')

--- a/provider/mapbox/app.js
+++ b/provider/mapbox/app.js
@@ -1,53 +1,70 @@
-mapboxgl.accessToken = '___MAPBOX_ACCESS_TOKEN___'
+;(async () => {
+  mapboxgl.accessToken = '___MAPBOX_ACCESS_TOKEN___'
 
-const map = new mapboxgl.Map({
-  container: 'map',
-  hash: true,
-  style: `http://${window.location.host}/style.json`,
-})
+  const mapStyleUrl = `http://${window.location.host}/style.json`
+  const mapStyleRes = await fetch(mapStyleUrl)
+  const mapStyleJson = await mapStyleRes.json()
+  const mapTileUrl =
+    mapStyleJson['sources'][Object.keys(mapStyleJson['sources'])]['url']
+  const mapTileRes = await fetch(mapTileUrl)
+  const mapTileJson = await mapTileRes.json()
+  const bounds = mapTileJson.bounds
+  const center = mapTileJson.center
+    ? mapTileJson.center
+    : [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2]
+  const zoom = (mapTileJson.minzoom + mapTileJson.maxzoom) / 2
 
-const socket = new WebSocket('ws://localhost:___PORT___')
+  const map = new maplibregl.Map({
+    container: 'map',
+    hash: true,
+    style: mapStyleUrl,
+    center: center,
+    zoom: zoom + 2,
+  })
 
-socket.addEventListener('message', (message) => {
-  map.setStyle(JSON.parse(message.data))
-})
+  const socket = new WebSocket('ws://localhost:___PORT___')
 
-map.addControl(new mapboxgl.NavigationControl(), 'top-right')
+  socket.addEventListener('message', (message) => {
+    map.setStyle(JSON.parse(message.data))
+  })
 
-map.addControl(
-  new MapboxLegendControl(
-    {},
-    {
-      showDefault: true,
-      showCheckbox: true,
-      onlyRendered: true,
-      reverseOrder: true,
-      accesstoken: mapboxgl.accessToken,
-    },
-  ),
-  'bottom-left',
-)
+  map.addControl(new mapboxgl.NavigationControl(), 'top-right')
 
-const showTileBoundaries = document.getElementById('showTileBoundaries')
-const setShowTileBoundaries = function () {
-  const checked = showTileBoundaries.checked
-  map.showTileBoundaries = checked
-}
-setShowTileBoundaries()
-showTileBoundaries.addEventListener('click', setShowTileBoundaries)
+  map.addControl(
+    new MapboxLegendControl(
+      {},
+      {
+        showDefault: true,
+        showCheckbox: true,
+        onlyRendered: true,
+        reverseOrder: true,
+        accesstoken: mapboxgl.accessToken,
+      },
+    ),
+    'bottom-left',
+  )
 
-const showCollisionBoxes = document.getElementById('showCollisionBoxes')
-const setShowCollisionBoxes = function () {
-  const checked = showCollisionBoxes.checked
-  map.showCollisionBoxes = checked
-}
-setShowCollisionBoxes()
-showCollisionBoxes.addEventListener('click', setShowCollisionBoxes)
+  const showTileBoundaries = document.getElementById('showTileBoundaries')
+  const setShowTileBoundaries = function () {
+    const checked = showTileBoundaries.checked
+    map.showTileBoundaries = checked
+  }
+  setShowTileBoundaries()
+  showTileBoundaries.addEventListener('click', setShowTileBoundaries)
 
-const showPadding = document.getElementById('showPadding')
-const setShowPadding = function () {
-  const checked = showPadding.checked
-  map.showPadding = checked
-}
-setShowPadding()
-showPadding.addEventListener('click', setShowPadding)
+  const showCollisionBoxes = document.getElementById('showCollisionBoxes')
+  const setShowCollisionBoxes = function () {
+    const checked = showCollisionBoxes.checked
+    map.showCollisionBoxes = checked
+  }
+  setShowCollisionBoxes()
+  showCollisionBoxes.addEventListener('click', setShowCollisionBoxes)
+
+  const showPadding = document.getElementById('showPadding')
+  const setShowPadding = function () {
+    const checked = showPadding.checked
+    map.showPadding = checked
+  }
+  setShowPadding()
+  showPadding.addEventListener('click', setShowPadding)
+})()

--- a/provider/mapbox/app.js
+++ b/provider/mapbox/app.js
@@ -15,7 +15,7 @@ socket.addEventListener('message', (message) => {
 map.addControl(new mapboxgl.NavigationControl(), 'top-right')
 
 map.addControl(
-  new watergis.MapboxLegendControl(
+  new MapboxLegendControl(
     {},
     {
       showDefault: true,


### PR DESCRIPTION

## Description

- Appropriately calculate the area to be displayed when charites serve is launched, based on style.yml
- This makes it easier to start editing styles

### Note

- This pull request has blocked by following issue and pull requests
  - #117
  - #118
- Please review #118 before this pull request



## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Others (Brush up)
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the exsiting features working well
- [x] Have you added at least one unit test if you are going to add new feature?
- [x] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
