### PR TITLE
Support slash in layer ID

### DIFF
--- a/src/lib/yaml-writer.ts
+++ b/src/lib/yaml-writer.ts
@@ -47,9 +47,10 @@ const writeDecompositedYaml = (
     const layer = style.layers[i]
     const layerYml = YAML.dump(layer)
     const fileName = `${style.layers[i].id}.yml`
-    const dirName = path.join(path.dirname(destinationPath), 'layers')
-    fs.mkdirSync(dirName, { recursive: true })
-    fs.writeFileSync(path.join(dirName, fileName), layerYml)
+    const layersDirName = path.join(path.dirname(destinationPath), 'layers')
+    const filePath = path.join(layersDirName, fileName)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, layerYml)
     // @ts-ignore
     layers.push(`!!inc/file ${path.join('layers', fileName)}`)
   }

--- a/src/lib/yaml-writer.ts
+++ b/src/lib/yaml-writer.ts
@@ -51,8 +51,11 @@ const writeDecompositedYaml = (
     const filePath = path.join(layersDirName, fileName)
     fs.mkdirSync(path.dirname(filePath), { recursive: true })
     fs.writeFileSync(filePath, layerYml)
+
+    // ts-ignore is required here because !!inc/file string is not compatible with the Layer object type.
+    // We use path.posix.join to make sure the path uses / path separators, even when run on Windows.
     // @ts-ignore
-    layers.push(`!!inc/file ${path.join('layers', fileName)}`)
+    layers.push(`!!inc/file ${path.posix.join('layers', fileName)}`)
   }
 
   style.layers = layers


### PR DESCRIPTION
## Description

Fix #56 by creating directories recursively after joining the layers directory with the layer ID. Before this fix, the layers directory was being created, but if the ID contained a slash, it would try to write the file to an nonexistent directory, resulting in an error.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the exsiting features working well
- [ ] Have you added at least one unit test if you are going to add new feature?
- [ ] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
