### PR TITLE
Fix options style in docs so that they appear correctly.

### DIFF
--- a/docs/source/usage/commandline_interface.rst
+++ b/docs/source/usage/commandline_interface.rst
@@ -92,11 +92,11 @@ Realtime editor on browser
 
 Charites has three options for `serve` command.
 
-- `--provider` - `mapbox`, `geolonia`, or `default`. When not specified, default or the value in the configuration file will be used.
+- ``--provider`` - `mapbox`, `geolonia`, or `default`. When not specified, default or the value in the configuration file will be used.
 
   - `mapbox` - The format linter runs against the Mapbox GL JS v2.x compatible specification.
   - `geolonia` and `default` - the format linter runs against the MapLibre GL JS compatible specification.
 
-- `--mapbox-access-token` - Set your access-token when styling for Mapbox.
+- ``--mapbox-access-token`` - Set your access-token when styling for Mapbox.
 
-- `--port` - Set http server's port number. When not specified, use 8080 port.
+- ``--port`` - Set http server's port number. When not specified, use 8080 port.

--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -29,14 +29,14 @@ Build `style.json` from `style.yml`:
 
     charites build style.yml style.json
 
-Add `-c` or `--compact-output` to minify the JSON
+Add ``-c`` or ``--compact-output`` to minify the JSON
 
 .. code-block:: bash
 
     charites build style.yml style.json -c
 
 
-Add `--sprite-input` and `--sprite-output` to build svg files for map icons.
+Add ``--sprite-input`` and ``--sprite-output`` to build svg files for map icons.
 
 .. code-block:: bash
 


### PR DESCRIPTION
For example, --<something> appeared like -<something> incorrectly before this changes.
