### PR TITLE
Support for sprites on serve

### DIFF
--- a/docs/source/usage/commandline_interface.rst
+++ b/docs/source/usage/commandline_interface.rst
@@ -85,10 +85,12 @@ Realtime editor on browser
     serve your map locally
 
     Options:
-    --provider [provider]                      your map service. e.g. `mapbox`, `geolonia`
-    --mapbox-access-token [mapboxAccessToken]  Access Token for the Mapbox
-    --port [port]                              Specify custom port
-    -h, --help                                 display help for command
+    --provider [provider]                        your map service. e.g. `mapbox`, `geolonia`
+    --mapbox-access-token [mapboxAccessToken]    Access Token for the Mapbox
+    -i, --sprite-input [<icon input directory>]  directory path of icon source to build icons. The default <icon
+                                                 source> is `icons/`
+    --port [port]                                Specify custom port
+    -h, --help                                   display help for command
 
 Charites has three options for `serve` command.
 
@@ -99,4 +101,6 @@ Charites has three options for `serve` command.
 
 - ``--mapbox-access-token`` - Set your access-token when styling for Mapbox.
 
-- ``--port`` - Set http server's port number. When not specified, use 8080 port.
+- ``--sprite-input`` - If you are building icon spritesheets with Charites, you can specify the directory of SVG files to compile here. See the ``build`` command for more information.
+
+- ``--port`` - Set http server's port number. When not specified, the default is 8080.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "fs-extra": "^10.0.0",
         "kill-port-process": "^3.0.1",
         "mocha": "^8.0.1",
+        "node-abort-controller": "^3.0.1",
         "prettier": "^2.5.0",
         "ts-node": "^8.10.2",
         "typescript": "^3.9.5"
@@ -2425,6 +2426,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==",
+      "dev": true
     },
     "node_modules/node-watch": {
       "version": "0.7.2",
@@ -5508,6 +5515,12 @@
       "requires": {
         "semver": "^7.3.5"
       }
+    },
+    "node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==",
+      "dev": true
     },
     "node-watch": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@mapbox/mapbox-gl-style-spec": "^13.22.0",
     "@maplibre/maplibre-gl-style-spec": "^14.0.2",
-    "@unvt/sprite-one": "^0.0.8",
     "@types/jsonminify": "^0.4.1",
+    "@unvt/sprite-one": "^0.0.8",
     "axios": "^0.24.0",
     "commander": "^8.2.0",
     "glob": "^7.2.0",
@@ -50,6 +50,7 @@
     "fs-extra": "^10.0.0",
     "kill-port-process": "^3.0.1",
     "mocha": "^8.0.1",
+    "node-abort-controller": "^3.0.1",
     "prettier": "^2.5.0",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.5"

--- a/provider/default/app.js
+++ b/provider/default/app.js
@@ -9,9 +9,7 @@
   if (zoom) options.zoom = zoom
   const map = new maplibregl.Map(options)
 
-  window._charites.initializeWebSocket((message) => {
-    map.setStyle(JSON.parse(message.data))
-  })
+  window._charites.initializeWebSocket(map)
 
   map.addControl(new maplibregl.NavigationControl(), 'top-right')
 

--- a/provider/default/shared.js
+++ b/provider/default/shared.js
@@ -1,9 +1,18 @@
 ;(async () => {
   window._charites = {
-    initializeWebSocket: function (onmessage) {
+    initializeWebSocket: function (map) {
       const socket = new WebSocket(`ws://${window.location.host}`)
 
-      socket.addEventListener('message', onmessage)
+      socket.addEventListener('message', (message) => {
+        const data = JSON.parse(message.data)
+        if (data.event === 'styleUpdate') {
+          map.setStyle(`http://${window.location.host}/style.json`)
+        } else if (data.event === 'spriteUpdate') {
+          map.setStyle(`http://${window.location.host}/style.json`, {
+            diff: false,
+          })
+        }
+      })
     },
     parseMapStyle: async function () {
       const mapStyleUrl = `http://${window.location.host}/style.json`

--- a/provider/geolonia/app.js
+++ b/provider/geolonia/app.js
@@ -9,9 +9,7 @@
   if (zoom) options.zoom = zoom
   const map = new geolonia.Map(options)
 
-  window._charites.initializeWebSocket((message) => {
-    map.setStyle(JSON.parse(message.data))
-  })
+  window._charites.initializeWebSocket(map)
 
   map.addControl(
     new MaplibreLegendControl(

--- a/provider/mapbox/app.js
+++ b/provider/mapbox/app.js
@@ -11,9 +11,7 @@
   if (zoom) options.zoom = zoom
   const map = new mapboxgl.Map(options)
 
-  window._charites.initializeWebSocket((message) => {
-    map.setStyle(JSON.parse(message.data))
-  })
+  window._charites.initializeWebSocket(map)
 
   map.addControl(new mapboxgl.NavigationControl(), 'top-right')
 

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -17,12 +17,19 @@ program
     '--mapbox-access-token [mapboxAccessToken]',
     'Your Mapbox Access Token (required if using the `mapbox` provider)',
   )
+  .option(
+    '-i, --sprite-input [<icon input directory>]',
+    'directory path of icon source to build icons. The default <icon source> is `icons/`',
+  )
   .option('--port [port]', 'Specify custom port')
-  .action((source: string, serveOptions: serveOptions) => {
+  .option('--no-open', "Don't open the preview in the default browser")
+  .action(async (source: string, serveOptions: serveOptions) => {
     const options: serveOptions = program.opts()
     options.provider = serveOptions.provider
     options.mapboxAccessToken = serveOptions.mapboxAccessToken
     options.port = serveOptions.port
+    options.spriteInput = serveOptions.spriteInput
+    options.open = serveOptions.open
     if (!fs.existsSync(defaultSettings.configFile)) {
       fs.writeFileSync(
         defaultSettings.configFile,
@@ -30,7 +37,7 @@ program
       )
     }
     try {
-      serve(source, program.opts())
+      await serve(source, program.opts())
     } catch (e) {
       error(e)
     }

--- a/test/command.serve.spec.ts
+++ b/test/command.serve.spec.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai'
+import { AbortController } from 'node-abort-controller'
+import axios from 'axios'
+import { abortableExecFile } from './util/execPromise'
+import { copyFixturesDir, copyFixturesFile } from './util/copyFixtures'
+import { makeTempDir } from './util/makeTempDir'
+import { charitesCliJs } from './util/charitesCmd'
+import { sleep } from './util'
+
+let tmpdir = ''
+
+describe('Test for `charites serve`', () => {
+  beforeEach(async function () {
+    tmpdir = makeTempDir()
+    copyFixturesFile('style.yml', tmpdir)
+    copyFixturesDir('layers', tmpdir)
+    copyFixturesDir('icons', tmpdir)
+  })
+
+  it('charites serve style.yml', async () => {
+    const abort = new AbortController()
+    const server = abortableExecFile(
+      process.execPath,
+      [charitesCliJs, 'serve', '--no-open', 'style.yml'],
+      abort.signal,
+      tmpdir,
+    )
+    try {
+      await sleep(500)
+      await Promise.all([
+        (async () => {
+          const res = await axios('http://localhost:8080/style.json', {})
+          expect(res.data.version).to.equal(8)
+        })(),
+        (async () => {
+          await axios('http://localhost:8080/sprite.json', {
+            validateStatus: (status) => status === 404,
+          })
+        })(),
+      ])
+    } finally {
+      abort.abort()
+    }
+    abort.abort()
+    const { stdout, stderr } = await server
+    expect(stderr).to.equal('')
+    expect(stdout).to.match(/^Your map is running on http:\/\/localhost:8080/m)
+  })
+
+  it('charites serve --sprite-input ./icons style.yml', async () => {
+    const abort = new AbortController()
+    const server = abortableExecFile(
+      process.execPath,
+      [
+        charitesCliJs,
+        'serve',
+        '--no-open',
+        '--sprite-input',
+        './icons',
+        'style.yml',
+      ],
+      abort.signal,
+      tmpdir,
+    )
+
+    try {
+      await sleep(500)
+      await Promise.all([
+        (async () => {
+          const res = await axios('http://localhost:8080/style.json', {})
+          expect(res.status).to.equal(200)
+          expect(res.data.version).to.equal(8)
+          expect(res.data.sprite).to.equal('http://localhost:8080/sprite')
+        })(),
+        (async () => {
+          const res = await axios('http://localhost:8080/sprite.json', {})
+          expect(res.status).to.equal(200)
+          expect(Object.entries(res.data).length).to.be.greaterThan(0)
+        })(),
+        (async () => {
+          const res = await axios('http://localhost:8080/sprite@2x.json', {})
+          expect(res.status).to.equal(200)
+          expect(Object.entries(res.data).length).to.be.greaterThan(0)
+        })(),
+        (async () => {
+          const res = await axios('http://localhost:8080/sprite.png', {})
+          expect(res.status).to.equal(200)
+          expect(res.data.length).to.be.greaterThan(0)
+        })(),
+        (async () => {
+          const res = await axios('http://localhost:8080/sprite@2x.png', {})
+          expect(res.status).to.equal(200)
+          expect(res.data.length).to.be.greaterThan(0)
+        })(),
+      ])
+    } finally {
+      abort.abort()
+    }
+    const { stdout, stderr } = await server
+    expect(stderr).to.equal('')
+    expect(stdout).to.match(/^Your map is running on http:\/\/localhost:8080/m)
+  })
+})

--- a/test/util/charitesCmd.ts
+++ b/test/util/charitesCmd.ts
@@ -1,3 +1,5 @@
 import path from 'path'
 
-export default `node ${path.join(__dirname, '..', '..', 'dist', 'cli.js')}`
+export const charitesCliJs = path.join(__dirname, '..', '..', 'dist', 'cli.js')
+
+export default `${process.execPath} ${charitesCliJs}`

--- a/test/util/execPromise.ts
+++ b/test/util/execPromise.ts
@@ -1,9 +1,22 @@
 import child_process from 'child_process'
 import util from 'util'
+
+// MEMO: Remove node-abort-controller when requiring NodeJS >=16
+// NOTE: AbortController is available by default from NodeJS 15
+import { AbortSignal } from 'node-abort-controller'
 import { makeTempDir } from './makeTempDir'
 const execSync = util.promisify(child_process.exec)
 
-export const exec = async (cmd: string, cwd?: string) => {
+type ExecResult = {
+  stdout: string
+  stderr: string
+  cwd: string
+}
+
+export const exec: (cmd: string, cwd?: string) => Promise<ExecResult> = async (
+  cmd,
+  cwd,
+) => {
   const temp = cwd ? cwd : makeTempDir()
   const { stdout, stderr } = await execSync(cmd, {
     encoding: 'utf8',
@@ -12,3 +25,34 @@ export const exec = async (cmd: string, cwd?: string) => {
 
   return { stdout, stderr, cwd: temp }
 }
+
+// MEMO: This can be replaced with the native AbortSignal support in child_process.exec after
+// requiring NodeJS >= 16.4.0, see:
+// https://nodejs.org/docs/latest-v16.x/api/child_process.html#child_processexeccommand-options-callback
+export const abortableExecFile = (
+  file: string,
+  args: string[],
+  signal: AbortSignal,
+  cwd?: string,
+) =>
+  new Promise<ExecResult>((resolve, reject) => {
+    const temp = cwd ? cwd : makeTempDir()
+
+    const process = child_process.execFile(
+      file,
+      args,
+      {
+        encoding: 'utf8',
+        cwd: temp,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          return reject(error)
+        }
+        resolve({ stdout, stderr, cwd: temp })
+      },
+    )
+    signal.addEventListener('abort', () => {
+      process.kill('SIGINT')
+    })
+  })

--- a/test/util/index.ts
+++ b/test/util/index.ts
@@ -1,0 +1,3 @@
+import { promisify } from 'util'
+
+export const sleep = promisify(setTimeout)


### PR DESCRIPTION
Closes #137, closes #62 

When writing sprite support, I saw that there were no tests for the charites serve command, so I added some simple tests. While there were initially tests in #80, they were removed before merging because of some timeout issue. I think I've resolved those issues in this PR.

## Description

Adds sprite support to the `serve` command. Uses the same `--sprite-input` command line option as `build`.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the existing features working well
- [x] Have you added at least one unit test if you are going to add new feature?
- [x] Have you updated documentation?
<!-- ignore-task-list-end -->
