### PR TITLE
Fix !!inc/file syntax for long layer names

### DIFF
--- a/test/convert.spec.ts
+++ b/test/convert.spec.ts
@@ -4,14 +4,24 @@ import fs from 'fs'
 import os from 'os'
 
 import { convert } from '../src/commands/convert'
+import { build } from '../src/commands/build'
+
+let tmp: string
 
 describe('Test for the `convert.ts`.', () => {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'charites-'))
   const jsonPath = path.join(__dirname, 'data/convert.json')
-  const yamlPath = path.join(tmp, 'convert.yml')
-  const layerPath = path.join(tmp, 'layers/background.yml')
 
-  it('Should convert `data/convert.json` to YAML.', () => {
+  beforeEach(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'charites-'))
+  })
+
+  afterEach(async () => {
+    fs.rmSync(tmp, { recursive: true })
+  })
+
+  it('Should convert `data/convert.json` to YAML and the YAML should be valid.', async () => {
+    const yamlPath = path.join(tmp, 'convert.yml')
+
     convert(jsonPath, yamlPath)
     const yml = fs.readFileSync(yamlPath, 'utf-8')
 
@@ -27,13 +37,23 @@ sprite: https://sprites.geolonia.com/basic-white
 glyphs: https://glyphs.geolonia.com/{fontstack}/{range}.pbf
 layers:
   - !!inc/file layers/background.yml
+  - !!inc/file >-
+    layers/background-with-very-long-name-background-with-very-long-name-background-with-very-long-name.yml
 id: example
 `,
       yml,
     )
+
+    const outJsonPath = path.join(tmp, 'converted-back.json')
+    // This will throw an error if the outputted YAML was invalid
+    await build(yamlPath, outJsonPath, { provider: 'default' })
+    assert.isTrue(fs.existsSync(outJsonPath))
   })
 
   it('Should create layers directory.', () => {
+    const yamlPath = path.join(tmp, 'convert.yml')
+    const layerPath = path.join(tmp, 'layers/background.yml')
+
     convert(jsonPath, yamlPath)
 
     const result = fs.existsSync(layerPath)

--- a/test/data/convert.json
+++ b/test/data/convert.json
@@ -17,6 +17,13 @@
       "paint": {
         "background-color": "rgba(19, 28, 54, 1)"
       }
+    },
+    {
+      "id": "background-with-very-long-name-background-with-very-long-name-background-with-very-long-name",
+      "type": "background",
+      "paint": {
+        "background-color": "rgba(19, 28, 54, 1)"
+      }
     }
   ],
   "id": "example"


### PR DESCRIPTION
## Description

Fixes #127 

When `!!inc/file ...` is being added to layers as a string and replaced after that, the `>-` multiline operator comes first:

```
layers:
  - >-
    !!inc/file layers/long-name
```

However, the correct syntax is:

```
layers:
  - !!inc/file >-
    layers/long-name
```

By changing the method from adding `!!inc/file` as a string, I created a temporary YAML schema that will output the correct multiline syntax.

A test was added to make sure the output of convert can be built again without errors.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the existing features working well
- [x] Have you added at least one unit test if you are going to add new feature?
- [ ] Have you updated documentation?
<!-- ignore-task-list-end -->
