### PR TITLE
Keep running `build --watch` even if the build fails

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -107,16 +107,25 @@ export function buildWatch(
     sourcePath = source
   }
   console.log(path.dirname(sourcePath))
+
+  const watchCallback = async (event: 'update' | 'remove', file: string) => {
+    console.log(`${(event || '').toUpperCase()}: ${file}`)
+    try {
+      await build(source, destination, options)
+    } catch (e) {
+      // Nothing to do
+      console.warn(
+        `WARN: Ignored error in ${file}:\n${e}\nFix the errors above, and try saving the file again.`,
+      )
+    }
+  }
+
+  // Trigger the watch callback first manually, so the user doesn't need to save the file to create the initial file.
+  watchCallback('update', sourcePath)
+
   return watch(
     path.dirname(sourcePath),
     { recursive: true, filter: /\.yml$/ },
-    (event, file) => {
-      console.log(`${(event || '').toUpperCase()}: ${file}`)
-      try {
-        build(source, destination, options)
-      } catch (e) {
-        // Nothing to do
-      }
-    },
+    watchCallback,
   )
 }


### PR DESCRIPTION
Closes #150

## Description

This pull request ignores failures and logs them to the console when using `charites build --watch ...`
It also runs build once when you first run `charites build --watch` (before this patch, one would have to save the file to get the initial build to run)

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the existing features working well
- [ ] Have you added at least one unit test if you are going to add new feature?
- [ ] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
