### PR TITLE
Fix error when bounds not found in neither style nor tilejson

### DIFF
--- a/provider/default/shared.js
+++ b/provider/default/shared.js
@@ -40,8 +40,12 @@
             if (center === undefined) {
               const bounds = mapTileJson.bounds
               center = mapTileJson.center
-                ? mapTileJson.center
-                : [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2]
+              if (!center && bounds) {
+                center = [
+                  (bounds[0] + bounds[2]) / 2,
+                  (bounds[1] + bounds[3]) / 2,
+                ]
+              }
             }
             if (zoom === undefined) {
               zoom = (mapTileJson.minzoom + mapTileJson.maxzoom) / 2


### PR DESCRIPTION
## Description

If bounds was not found in style, shared.js would calculate the default center from the bounds in TileJSON. However, if bounds was not in TileJSON, an error occurred. This fixes that error by checking if the bounds exist before trying to calculate the center.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the existing features working well
- [ ] Have you added at least one unit test if you are going to add new feature?
- [ ] Have you updated documentation?
<!-- ignore-task-list-end -->
