### PR TITLE
feat: add --sdf option to allow users to use SDF sprite in serve command

### DIFF
--- a/docs/source/usage/commandline_interface.rst
+++ b/docs/source/usage/commandline_interface.rst
@@ -98,6 +98,7 @@ Realtime editor on browser
     --mapbox-access-token [mapboxAccessToken]    Access Token for the Mapbox
     -i, --sprite-input [<icon input directory>]  directory path of icon source to build icons. The default <icon
                                                  source> is `icons/`
+    --sdf                                        Allows to use SDF sprite in charites
     --port [port]                                Specify custom port
     -h, --help                                   display help for command
 
@@ -111,5 +112,7 @@ Charites has three options for `serve` command.
 - ``--mapbox-access-token`` - Set your access-token when styling for Mapbox.
 
 - ``--sprite-input`` - If you are building icon spritesheets with Charites, you can specify the directory of SVG files to compile here. See the ``build`` command for more information.
+
+- ``--sdf`` - if this option is used together with ``--sprite-input``, the viewer will generate SDF sprite. If the option is not specified, non SDF sprite will be generated.
 
 - ``--port`` - Set http server's port number. When not specified, the default is 8080.

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -21,6 +21,7 @@ program
     '-i, --sprite-input [<icon input directory>]',
     'directory path of icon source to build icons. The default <icon source> is `icons/`',
   )
+  .option('--sdf', 'Allows to use SDF sprite in charites')
   .option('--port [port]', 'Specify custom port')
   .option('--no-open', "Don't open the preview in the default browser")
   .action(async (source: string, serveOptions: serveOptions) => {
@@ -30,6 +31,7 @@ program
     options.port = serveOptions.port
     options.spriteInput = serveOptions.spriteInput
     options.open = serveOptions.open
+    options.sdf = serveOptions.sdf
     if (!fs.existsSync(defaultSettings.configFile)) {
       fs.writeFileSync(
         defaultSettings.configFile,

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -17,6 +17,7 @@ export interface serveOptions {
   port?: string
   spriteInput?: string
   open?: boolean
+  sdf?: boolean
 }
 
 export async function serve(source: string, options: serveOptions) {
@@ -57,7 +58,7 @@ export async function serve(source: string, options: serveOptions) {
       ) {
         return
       }
-      await buildSprite(options.spriteInput, spriteOut, 'sprite')
+      await buildSprite(options.spriteInput, spriteOut, 'sprite', options.sdf)
     }
     await spriteRefresher()
   }

--- a/src/lib/build-sprite.ts
+++ b/src/lib/build-sprite.ts
@@ -5,9 +5,10 @@ export async function buildSprite(
   svgPath: string,
   publicPath: string,
   iconSlug: string,
+  sdf = false,
 ): Promise<void> {
   const pxRatios = [1, 2]
   const outPath = path.join(publicPath, iconSlug)
-  await generateSprite(outPath, [svgPath], pxRatios)
+  await generateSprite(outPath, [svgPath], pxRatios, sdf)
   return
 }


### PR DESCRIPTION
@smellman 

## Description

closes #175

I tested with the following command to have confirmed SDF sprite is served as localhost

```shell
charites serve --sprite-input=test/data/icons --sdf test/data/style.yml
```

It would be nice if `--sdf` option is available in build command, but that is not urgent since sprite-one can be directly used to build sprite files, hence I only added this option for serve command

## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the existing features working well
- [x] Have you added at least one unit test if you are going to add new feature?
- [x] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
