### PR TITLE
chore: Remove axios dependency and change to use fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@maplibre/maplibre-gl-style-spec": "^23.2.2",
         "@unvt/sprite-one": "^0.1.1",
         "@watergis/maplibre-gl-legend": "^2.0.5",
-        "axios": "^1.9.0",
         "commander": "^13.1.0",
         "glob": "^11.0.2",
         "js-yaml": "^4.1.0",
@@ -2353,17 +2352,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -5244,11 +5232,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -8078,16 +8061,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
-    "axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "requires": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -10087,11 +10060,6 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@maplibre/maplibre-gl-style-spec": "^23.2.2",
     "@unvt/sprite-one": "^0.1.1",
     "@watergis/maplibre-gl-legend": "^2.0.5",
-    "axios": "^1.9.0",
     "commander": "^13.1.0",
     "glob": "^11.0.2",
     "js-yaml": "^4.1.0",

--- a/src/lib/tileinfo-importer/metadata-importer.ts
+++ b/src/lib/tileinfo-importer/metadata-importer.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { MetadataJSON, VectorLayer } from '../../types/index.js'
 import {
   LayerSpecification,
@@ -8,8 +7,8 @@ import { BaseImporter, TileInfoJSONResponse } from './base-importer.js'
 
 export class MetadataJSONImporter extends BaseImporter {
   async getJSON(url: string): Promise<TileInfoJSONResponse> {
-    const res = await axios.get(url)
-    const matadataJSON: MetadataJSON = res.data
+    const res = await fetch(url)
+    const matadataJSON: MetadataJSON = await res.json()
     const metadataName: string = matadataJSON.name
       ? matadataJSON.name
       : Math.random().toString(32).substring(2)

--- a/src/lib/tileinfo-importer/tilejson-importer.ts
+++ b/src/lib/tileinfo-importer/tilejson-importer.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { TileJSON } from '../../types/index.js'
 import {
   SourceSpecification,
@@ -8,8 +7,8 @@ import { BaseImporter, TileInfoJSONResponse } from './base-importer.js'
 
 export class TileJSONImporter extends BaseImporter {
   async getJSON(url: string): Promise<TileInfoJSONResponse> {
-    const res = await axios.get(url)
-    const tilejson: TileJSON = res.data
+    const res = await fetch(url)
+    const tilejson: TileJSON = await res.json()
     const tilesetName: string = tilejson.name
       ? tilejson.name
       : Math.random().toString(32).substring(2)

--- a/test/command.serve.spec.ts
+++ b/test/command.serve.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai'
 import { AbortController } from 'node-abort-controller'
-import axios from 'axios'
 import { abortableExecFile } from './util/execPromise'
 import { copyFixturesDir, copyFixturesFile } from './util/copyFixtures'
 import { makeTempDir } from './util/makeTempDir'
@@ -29,13 +28,13 @@ describe('Test for `charites serve`', () => {
       await sleep(500)
       await Promise.all([
         (async () => {
-          const res = await axios('http://127.0.0.1:8080/style.json', {})
-          expect(res.data.version).to.equal(8)
+          const res = await fetch('http://127.0.0.1:8080/style.json')
+          const data = await res.json()
+          expect(data.version).to.equal(8)
         })(),
         (async () => {
-          await axios('http://127.0.0.1:8080/sprite.json', {
-            validateStatus: (status) => status === 404,
-          })
+          const res = await fetch('http://127.0.0.1:8080/sprite.json')
+          expect(res.status).to.equal(404)
         })(),
       ])
     } finally {
@@ -67,30 +66,35 @@ describe('Test for `charites serve`', () => {
       await sleep(500)
       await Promise.all([
         (async () => {
-          const res = await axios('http://127.0.0.1:8080/style.json', {})
+          const res = await fetch('http://127.0.0.1:8080/style.json')
           expect(res.status).to.equal(200)
-          expect(res.data.version).to.equal(8)
-          expect(res.data.sprite).to.equal('http://127.0.0.1:8080/sprite')
+          const data = await res.json()
+          expect(data.version).to.equal(8)
+          expect(data.sprite).to.equal('http://127.0.0.1:8080/sprite')
         })(),
         (async () => {
-          const res = await axios('http://127.0.0.1:8080/sprite.json', {})
+          const res = await fetch('http://127.0.0.1:8080/sprite.json')
           expect(res.status).to.equal(200)
-          expect(Object.entries(res.data).length).to.be.greaterThan(0)
+          const data = await res.json()
+          expect(Object.entries(data).length).to.be.greaterThan(0)
         })(),
         (async () => {
-          const res = await axios('http://127.0.0.1:8080/sprite@2x.json', {})
+          const res = await fetch('http://127.0.0.1:8080/sprite@2x.json')
           expect(res.status).to.equal(200)
-          expect(Object.entries(res.data).length).to.be.greaterThan(0)
+          const data = await res.json()
+          expect(Object.entries(data).length).to.be.greaterThan(0)
         })(),
         (async () => {
-          const res = await axios('http://127.0.0.1:8080/sprite.png', {})
+          const res = await fetch('http://127.0.0.1:8080/sprite.png')
           expect(res.status).to.equal(200)
-          expect(res.data.length).to.be.greaterThan(0)
+          const buffer = await res.arrayBuffer()
+          expect(buffer.byteLength).to.be.greaterThan(0)
         })(),
         (async () => {
-          const res = await axios('http://127.0.0.1:8080/sprite@2x.png', {})
+          const res = await fetch('http://127.0.0.1:8080/sprite@2x.png')
           expect(res.status).to.equal(200)
-          expect(res.data.length).to.be.greaterThan(0)
+          const buffer = await res.arrayBuffer()
+          expect(buffer.byteLength).to.be.greaterThan(0)
         })(),
       ])
     } finally {


### PR DESCRIPTION

## Description

Replace axios with Node.js native fetch API to reduce external dependencies. This change improves maintainability and reduces the project's dependency footprint.

**The axios library has known security vulnerabilities that could potentially expose applications to security risks. Using Node.js native fetch API eliminates these concerns while providing the same functionality.**

Changes include:
- Replaced axios with fetch in test/command.serve.spec.ts
- Updated tilejson-importer.ts to use fetch instead of axios
- Updated metadata-importer.ts to use fetch instead of axios
- Updated response handling to match fetch API patterns

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the existing features working well
- [x] Have you added at least one unit test if you are going to add new feature?
- [x] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.