### PR TITLE
fix: update default sprite URL if style.sprite is array in serve command.

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -87,9 +87,29 @@ export async function serve(source: string, options: serveOptions) {
         try {
           style = parser(sourcePath)
           if (typeof spriteOut !== 'undefined') {
-            style.sprite = `http://${
+            const spriteUrl = `http://${
               req.headers.host || `localhost:${port}`
             }/sprite`
+
+            if (typeof style.sprite === 'string') {
+              // update a single sprite URL
+              style.sprite = spriteUrl
+            } else if (Array.isArray(style.sprite)) {
+              // if sprite is an array, update default sprite URL.
+              // if default sprite is not found, add default url.
+              if (style.sprite.find((s) => s.id === 'default')) {
+                for (const s of style.sprite) {
+                  if (s.id === 'default') {
+                    s.url = spriteUrl
+                  }
+                }
+              } else {
+                style.sprite.push({
+                  id: 'default',
+                  url: spriteUrl,
+                })
+              }
+            }
           }
           validateStyle(style)
         } catch (error) {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #200

current serve command force overwrite sprite property by a single URL if --sprite-input option is used even if sprite has multiple URLs in an array.

This PR fixes to only update default sprite URL in sprite property. Or, it will add default sprite URL if it does not exist. So, other sprite URLs in style.sprite property can be kept.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No build errors after `npm run build`
- [x] No lint errors after `npm run lint`
- [x] No errors on using `charites help` globally
- [x] Make sure all the existing features working well
- [ ] Have you added at least one unit test if you are going to add new feature?
- [ ] Have you updated documentation?
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/unvt/charites/tree/master/.github/CONTRIBUTING.md) for more details.
